### PR TITLE
Disable touch drag selection in the body of the case table

### DIFF
--- a/slick.grid.js
+++ b/slick.grid.js
@@ -398,7 +398,7 @@ if (typeof Slick === "undefined") {
             .bind("click", handleClick)
             .bind("dblclick", handleDblClick)
             .bind("contextmenu", handleContextMenu)
-            .bind("draginit", handleDragInit)
+            .bind("draginit", {touch: false}, handleDragInit)
             .bind("dragstart", {distance: 3}, handleDragStart)
             .bind("drag", handleDrag)
             .bind("dragend", handleDragEnd)


### PR DESCRIPTION
Disable touch drag selection in the body of the case table to make it easier to scroll

Note that this requires a modified version of the `jquery.event.drag` library as well, which is part of the CODAP repository.